### PR TITLE
Revert "headers-more-nginx-module 0.261 (#392)"

### DIFF
--- a/Formula/headers-more-nginx-module.rb
+++ b/Formula/headers-more-nginx-module.rb
@@ -1,8 +1,8 @@
 class HeadersMoreNginxModule < Formula
   desc "Set, add, and clear arbitrary output headers"
   homepage "https://github.com/openresty/headers-more-nginx-module"
-  url "https://github.com/openresty/headers-more-nginx-module/archive/v0.261.tar.gz"
-  sha256 "03d1f5fbecba8565f247d87a38f5e4b6440b0a56d752bdd2b29af2f1c4aea480"
+  url "https://github.com/openresty/headers-more-nginx-module/archive/v0.33.tar.gz"
+  sha256 "a3dcbab117a9c103bc1ea5200fc00a7b7d2af97ff7fd525f16f8ac2632e30fbf"
 
   def install
     pkgshare.install Dir["*"]


### PR DESCRIPTION
This reverts commit d1f325f3b019783d1ccd1d1ef6f3ba216d230b01.

### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/watermelonexpress/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/watermelonexpress/homebrew-nginx/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
